### PR TITLE
Fix typo in deploy repo link

### DIFF
--- a/about/open-source.md
+++ b/about/open-source.md
@@ -2,6 +2,6 @@
 
 All code for the platform is open source. You can find it in the [Github Organization](https://github.com/wbstack).
 
-wbstack.com was run using open source configuration. You can find this in the [old deploy repository](https://github.com/wbtack/deploy)
+wbstack.com was run using open source configuration. You can find this in the [old deploy repository](https://github.com/wbstack/deploy)
 
 wikibase.cloud does not currently have it's configuration repository open.


### PR DESCRIPTION
Found a typo in a link to the deploy repo